### PR TITLE
Increase confidentiality guarantees for reporters

### DIFF
--- a/index.md
+++ b/index.md
@@ -57,7 +57,7 @@ If you have questions, please see the [FAQ][]. If that doesn't answer your quest
 
 ## Reporting Guidelines
 
-If you believe someone is violating the Code of Conduct, we ask that you report it by emailing [tc39-conduct-reports@googlegroups.com][tc39-conduct]. **All reports will be kept confidential.**
+If you believe someone is violating the Code of Conduct, we ask that you report it by emailing [tc39-conduct-reports@googlegroups.com][tc39-conduct]. **All reports will be kept confidential.** See [Confidentiality][] for details.
 
 If the act is ongoing, the Chair, Vice-Chair or any member of the Code of Conduct Committee should take immediate measures to stop it if possible, and to gather the information described below.
 
@@ -78,6 +78,8 @@ Reports will receive urgent and immediate attention from the Code of Conduct Com
 ### Confidentiality
 
 The mailing list is addressed to members of [Code of Conduct Committee][], and reports will only be shared with others outside the Committee with permission of the reporter. No identity will be made public beyond the Code of Conduct Committee and the ECMA Executive Committee unless the individuals concerned have agreed to it. If you would prefer to share your report with only certain members of the Code of Conduct Committee, you may email it to a subset using their listed email addresses; this subset will not share the report with any others outside the subset without permission of the reporter.
+
+Although it is helpful for the Code of Conduct Committee to know a reporter's identity, the Committee will consider anonymous reports. Two avenues for submitting such an anonymous report that you may consider would be a throwaway email address, or onion routing via trusted intermediaries.
 
 ### Appealing
 
@@ -198,6 +200,7 @@ TC39 has specified further the terms of “prejudicial conduct” and has expand
 
 [TC39 Code of Conduct]: /code-of-conduct/
 [Code of Conduct Committee]: #code-of-conduct-committee
+[Confidentiality]: #confidentiality
 [Enforcement Manual]: #enforcement-manual
 [Reporting Guidelines]: #reporting-guidelines
 [FAQ]: #frequently-asked-questions

--- a/index.md
+++ b/index.md
@@ -57,7 +57,7 @@ If you have questions, please see the [FAQ][]. If that doesn't answer your quest
 
 ## Reporting Guidelines
 
-If you believe someone is violating the Code of Conduct, we ask that you report it by emailing [tc39-conduct-reports@googlegroups.com][tc39-conduct]. All reports will be kept confidential. Only members of the [Code of Conduct Committee][], and possibly the Ecma ExeCom, will receive the reports. No identity will be made public before the individuals concerned have agreed to it.
+If you believe someone is violating the Code of Conduct, we ask that you report it by emailing [tc39-conduct-reports@googlegroups.com][tc39-conduct]. **All reports will be kept confidential.**
 
 If the act is ongoing, the Chair, Vice-Chair or any member of the Code of Conduct Committee should take immediate measures to stop it if possible, and to gather the information described below.
 
@@ -74,6 +74,10 @@ In your report please include:
 ### What happens after you file a report?
 
 Reports will receive urgent and immediate attention from the Code of Conduct Committee. Please refer to the [Enforcement Manual][] for the complete information on how reports will be processed.
+
+### Confidentiality
+
+The mailing list is addressed to members of [Code of Conduct Committee][], and reports will only be shared with others outside the Committee with permission of the reporter. No identity will be made public beyond the Code of Conduct Committee and the ECMA Executive Committee unless the individuals concerned have agreed to it. If you would prefer to share your report with only certain members of the Code of Conduct Committee, you may email it to a subset using their listed email addresses; this subset will not share the report with any others outside the subset without permission of the reporter.
 
 ### Appealing
 
@@ -107,7 +111,7 @@ The Committee should aim to have a resolution agreed very rapidly; if not agreed
 
 ### Resolution
 
-The Committee must agree on a resolution by consensus. If the Committee cannot reach consensus, the Committee will turn the matter over to the Ecma ExeCom for resolution.
+The Committee must agree on a resolution by consensus. If the Committee cannot reach consensus, the Committee will turn the matter over to the Ecma ExeCom for resolution, after the Committee confirms with the reporter whether it is acceptable to share the report with the ExeCom.
 
 Responses will be determined by the Committee on the basis of the information gathered and of the potential consequences. It may include taking no further action, issuing a reprimand (private or public), asking for an apology (private or public), or contacting the company that the individual belongs to. It could even result in a temporary or permanent exclusion from some of the TC39 working spaces such as mailing lists or IRC. For any contemplated action other than a reprimand or an apology, the Committee shall inform the Ecma ExeCom. Any exclusion needs to follow the process described in the Ecma bylaws.
 
@@ -117,7 +121,7 @@ The Committee will never publicly discuss the issue; all public statements, if 
 
 ### Conflicts of Interest
 
-In the event of any conflict of interest - i.e., members who are personally connected to a situation, a Committee member must immediately notify the other members, and recuse themselves. 
+In the event of any conflict of interest - i.e., members who are personally connected to a situation, a Committee member must immediately notify the other members, and recuse themselves.
 
 ---
 
@@ -127,13 +131,13 @@ The Code of Conduct Committee deals with violations in the [TC39 Code of Conduct
 
 Committee Members:
 
-* TBD
-* TBD
-* TBD
-* TBD
-* TBD
+* Name (Email)
+* Name (Email)
+* Name (Email)
+* Name (Email)
+* Name (Email)
 
-You can contact [tc39-conduct][]. For more details please see the [Reporting Guidelines][].
+You can contact the group above by writing an email to [tc39-conduct][]. For more details please see the [Reporting Guidelines][].
 
 ---
 

--- a/index.md
+++ b/index.md
@@ -79,7 +79,7 @@ Reports will receive urgent and immediate attention from the Code of Conduct Com
 
 The mailing list is addressed to members of [Code of Conduct Committee][], and reports will only be shared with others outside the Committee with permission of the reporter. No identity will be made public beyond the Code of Conduct Committee and the ECMA Executive Committee unless the individuals concerned have agreed to it. If you would prefer to share your report with only certain members of the Code of Conduct Committee, you may email it to a subset using their listed email addresses; this subset will not share the report with any others outside the subset without permission of the reporter.
 
-Although it is helpful for the Code of Conduct Committee to know a reporter's identity, the Committee will consider anonymous reports. Two avenues for submitting such an anonymous report that you may consider would be a throwaway email address, or onion routing via trusted intermediaries.
+Although it is helpful for the Code of Conduct Committee to know a reporter's identity, the Committee will consider anonymous reports. Two avenues for submitting such an anonymous report that you may consider would be a throwaway email address, or having a colleague or friend submit a report on your behalf.
 
 ### Appealing
 


### PR DESCRIPTION
With this change, code of conduct violation reports will be only shared
with those who the reporter explicitly shares them with. Reports may
be sent to a subset of the committee if the reporter is uncomfortable
sharing the report with all members. Committee members' email addresses
are published to make them available for contact.

This change may need ExeCom review before merging.