### PR TITLE
Add CoC.md reference file

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,3 @@
+This repository is a TC39 project and subscribes to its [code of conduct](https://tc39.github.io/code-of-conduct/). It is available at [https://tc39.github.io/code-of-conduct/](https://tc39.github.io/code-of-conduct/). 
+
+To ask a question or report an issue, please email [tc39-conduct-reports@googlegroups.com](mailto:tc39-conduct-reports@googlegroups.com).


### PR DESCRIPTION
Adds CODE_OF_CONDUCT.md per inclusivity best practices (and per code-of-conduct/issues/35).