### PR TITLE
Fix capitalisation errors of `CODE_OF_CONDUCT.md`

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,3 +1,3 @@
-This repository is a TC39 project and subscribes to its [code of conduct](https://tc39.github.io/code-of-conduct/). It is available at [https://tc39.github.io/code-of-conduct/](https://tc39.github.io/code-of-conduct/). 
+This repository is a TC39 project and subscribes to its [Code of Conduct](https://tc39.github.io/code-of-conduct/). It is available at [https://tc39.github.io/code-of-conduct/](https://tc39.github.io/code-of-conduct/).
 
 To ask a question or report an issue, please email [tc39-conduct-reports@googlegroups.com](mailto:tc39-conduct-reports@googlegroups.com).


### PR DESCRIPTION
The same changes suggested in https://github.com/tc39/tc39.github.io/pull/315